### PR TITLE
chore: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+# All files
+[*]
+indent_style = space
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = true


### PR DESCRIPTION
First stab at .editorconfig to ensure consistent style, [copied basics from KubeOps](https://github.com/dotnet/dotnet-operator-sdk/blob/7d1187a2535517c661638fcdbab8e50baeb17407/.editorconfig#L1-L23).

------

A test PR.
